### PR TITLE
POSTYC-59: Updates logger to latest changes in yellowcube-php.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,9 @@
     "require":{
         "php": ">=5.3.2",
         "magento-hackathon/magento-composer-installer":"2.*",
-        "swisspost-yellowcube/yellowcube-php": "~1.0"
+        "swisspost-yellowcube/yellowcube-php": "~2.0"
+    },
+    "extra": {
+        "magento-root-dir": "."
     }
 }

--- a/src/app/code/community/Swisspost/YellowCube/Model/Library/Client.php
+++ b/src/app/code/community/Swisspost/YellowCube/Model/Library/Client.php
@@ -1,7 +1,9 @@
 <?php
 
+use Psr\Log\LogLevel;
 use YellowCube\Service;
 use YellowCube\Config;
+use YellowCube\Util\Logger\MinLevelFilterLogger;
 
 /**
  * Class Swisspost_YellowCube_Model_Library_Client
@@ -13,7 +15,7 @@ class Swisspost_YellowCube_Model_Library_Client
      */
     public function getService()
     {
-        $logger = new Swisspost_YellowCube_Model_Library_Logger();
+        $logger = new MinLevelFilterLogger(LogLevel::DEBUG, new Swisspost_YellowCube_Model_Library_Logger());
         return new YellowCube\Service($this->getServiceConfig(), null, $logger);
     }
 

--- a/src/app/code/community/Swisspost/YellowCube/Model/Library/Logger.php
+++ b/src/app/code/community/Swisspost/YellowCube/Model/Library/Logger.php
@@ -1,6 +1,6 @@
 <?php
 
-use YellowCube\Util\AbstractLogger;
+use Psr\Log\AbstractLogger;
 use Psr\Log\LogLevel;
 
 /**
@@ -27,20 +27,8 @@ class Swisspost_YellowCube_Model_Library_Logger extends AbstractLogger
     /**
      * @inheritdoc
      */
-    public function __construct($minLevel = LogLevel::DEBUG)
-    {
-        parent::__construct($minLevel);
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function log($level, $message, array $context = array())
     {
-        if ($this->isLevelLessThanMinimum($level)) {
-            return;
-        }
-
         Mage::log($message . print_r($context, true), self::$levelMap[$level], $this->logFileName, true);
     }
 }


### PR DESCRIPTION
I moved the former `AbstractLogger` into its own class (`MinLevelFilterLogger`) which can be used with any other logger. It is not necessary to extend from the `AbstractLogger` anymore.